### PR TITLE
fix(enums): accept S1CD APDN calibration code

### DIFF
--- a/s1isp/enums.py
+++ b/s1isp/enums.py
@@ -161,10 +161,11 @@ class ECalTypeS1CD(enum.IntEnum):
     TX_CAL = 0
     RX_CAL = 1
     EPDN_CAL = 2
-    TX_CAL_ISO = 3
     # TA_CAL = 3  # legacy S1AB name
-    APDN_CAL = 4  # observed in S1C raw products
-    _NOT_APPLICABLE_5 = 5  # observed in S1C raw products
+    TX_CAL_ISO = 3
+    # APDN_CAL = 4  # legacy S1AB name
+    _NOT_APPLICABLE_4 = 4  # observed in S1C raw products (see #11)
+    _NOT_APPLICABLE_5 = 5
     _NOT_APPLICABLE_6 = 6
     _NOT_APPLICABLE_7 = 7
 

--- a/s1isp/enums.py
+++ b/s1isp/enums.py
@@ -162,8 +162,8 @@ class ECalTypeS1CD(enum.IntEnum):
     RX_CAL = 1
     EPDN_CAL = 2
     TX_CAL_ISO = 3
-    # TA_CAL = 3
-    # APDN_CAL = 4
+    # TA_CAL = 3  # legacy S1AB name
+    APDN_CAL = 4  # observed in S1C raw products
     # _NOT_APPLICABLE_5 = 5
     # _NOT_APPLICABLE_6 = 6
     # TXH_CAL_ISO = 7

--- a/s1isp/enums.py
+++ b/s1isp/enums.py
@@ -164,9 +164,9 @@ class ECalTypeS1CD(enum.IntEnum):
     TX_CAL_ISO = 3
     # TA_CAL = 3  # legacy S1AB name
     APDN_CAL = 4  # observed in S1C raw products
-    # _NOT_APPLICABLE_5 = 5
-    # _NOT_APPLICABLE_6 = 6
-    # TXH_CAL_ISO = 7
+    _NOT_APPLICABLE_5 = 5  # observed in S1C raw products
+    _NOT_APPLICABLE_6 = 6
+    _NOT_APPLICABLE_7 = 7
 
 
 class ECalMode(enum.IntEnum):

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -6,3 +6,8 @@ from s1isp.enums import ECalTypeS1CD
 def test_cal_type_s1cd_apdn_cal_value():
     """Ensure S1CD calibration type code 4 is accepted."""
     assert ECalTypeS1CD(4) == ECalTypeS1CD.APDN_CAL
+
+
+def test_cal_type_s1cd_not_applicable_5_value():
+    """Ensure S1CD calibration type code 5 is accepted."""
+    assert ECalTypeS1CD(5) == ECalTypeS1CD._NOT_APPLICABLE_5

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,8 @@
+"""Tests for enum definitions."""
+
+from s1isp.enums import ECalTypeS1CD
+
+
+def test_cal_type_s1cd_apdn_cal_value():
+    """Ensure S1CD calibration type code 4 is accepted."""
+    assert ECalTypeS1CD(4) == ECalTypeS1CD.APDN_CAL

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,6 +1,16 @@
 """Tests for enum definitions."""
 
-from s1isp.enums import ECalTypeS1CD
+from s1isp.enums import ECalTypeS1AB, ECalTypeS1CD
+
+
+def test_cal_type_s1ab_values():
+    """Ensure S1AB calibration type code up to 7 are accepted."""
+    for idx in range(8):
+        assert ECalTypeS1AB(idx) == idx
+
+    # not applicable
+    for idx in range(5, 7):
+        assert ECalTypeS1AB(idx).name.startswith("_NOT_APPLICABLE")
 
 
 def test_cal_type_s1cd_values():

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -3,11 +3,11 @@
 from s1isp.enums import ECalTypeS1CD
 
 
-def test_cal_type_s1cd_apdn_cal_value():
-    """Ensure S1CD calibration type code 4 is accepted."""
-    assert ECalTypeS1CD(4) == ECalTypeS1CD.APDN_CAL
+def test_cal_type_s1cd_values():
+    """Ensure S1CD calibration type code up to 7 are accepted."""
+    for idx in range(8):
+        assert ECalTypeS1CD(idx) == idx
 
-
-def test_cal_type_s1cd_not_applicable_5_value():
-    """Ensure S1CD calibration type code 5 is accepted."""
-    assert ECalTypeS1CD(5) == ECalTypeS1CD._NOT_APPLICABLE_5
+    # not applicable
+    for idx in range(4, 8):
+        assert ECalTypeS1CD(idx).name.startswith("_NOT_APPLICABLE")


### PR DESCRIPTION
  - Add ECalTypeS1CD.APDN_CAL = 4 to support observed S1C packets.
  - Prevent decode failure on calibration type value 4.
  - Add regression test in tests/test_enums.py.

This prevents decoder failures when SAS calibration type code 4 is present. Add a regression test to ensure enum conversion for value 4 stays valid.